### PR TITLE
Documentation update + small fixes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@ Changelog of lizard-auth-client
 1.3 (unreleased)
 ----------------
 
-- Nothing changed yet.
+- Improved the documentation.
 
 
 1.2 (2015-04-29)

--- a/README.rst
+++ b/README.rst
@@ -15,17 +15,29 @@ Include this app as a dependency in setup.py::
       ...
   ],
 
+And add it to ``INSTALLED_APPS`` in your django settings::
+
+    INSTALLED_APPS = (
+        ...
+        'lizard_auth_client',
+        ...)
+
 Configure the SSO settings as seen in ``testsettings.py``::
 
-  # SSO
+  # SSO *can* be disabled for development with local accounts.
   SSO_ENABLED = True
+
+  # Create a portal on the SSO server, this generates the SSO_KEY and
+  # SSO_SECRET for you.
   # A key identifying this client. Can be published.
   SSO_KEY = 'random_generated_key_to_identify_the_client'
-  # A *secret* shared between client and server. Used to sign the messages exchanged between them.
+  # A *secret* shared between client and server.
+  # Used to sign the messages exchanged between them.
   SSO_SECRET = 'random_generated_secret_key_to_sign_exchanged_messages'
-  # URL used to redirect the user to the SSO server
+
+  # URL used to redirect the user to the SSO server.
   # Note: needs a trailing slash
-  SSO_SERVER_PUBLIC_URL = 'http://external-address.site.tld/'
+  SSO_SERVER_PUBLIC_URL = 'https://external-address.site.tld/'
   # URL used for server-to-server communication
   # Note: needs a trailing slash
   SSO_SERVER_PRIVATE_URL = 'http://10.0.0.1:80/'

--- a/README.rst
+++ b/README.rst
@@ -54,11 +54,6 @@ import them in the root of your urlpatterns::
         (r'^', include('lizard_auth_client.urls')),
     )
 
-There is an additional setting that you can use to limit the attributes that
-are copied from the SSO server. Normally ``is_staff`` and ``is_superuser`` is
-also copied, for instance. If you don't want that::
-
-    SSO_SYNCED_USER_KEYS = ['first_name', 'last_name', 'email', 'is_active']
 
 
 Usage note for django < 1.7

--- a/README.rst
+++ b/README.rst
@@ -9,11 +9,11 @@ Usage
 
 Include this app as a dependency in setup.py::
 
-  install_requires = [
-      ...
-      'lizard-auth-client',
-      ...
-  ],
+    install_requires = [
+        ...
+        'lizard-auth-client',
+        ...
+    ],
 
 And add it to ``INSTALLED_APPS`` in your django settings::
 
@@ -24,35 +24,35 @@ And add it to ``INSTALLED_APPS`` in your django settings::
 
 Configure the SSO settings as seen in ``testsettings.py``::
 
-  # SSO *can* be disabled for development with local accounts.
-  SSO_ENABLED = True
+    # SSO *can* be disabled for development with local accounts.
+    SSO_ENABLED = True
 
-  # Create a portal on the SSO server, this generates the SSO_KEY and
-  # SSO_SECRET for you.
-  # A key identifying this client. Can be published.
-  SSO_KEY = 'random_generated_key_to_identify_the_client'
-  # A *secret* shared between client and server.
-  # Used to sign the messages exchanged between them.
-  SSO_SECRET = 'random_generated_secret_key_to_sign_exchanged_messages'
+    # Create a portal on the SSO server, this generates the SSO_KEY and
+    # SSO_SECRET for you.
+    # A key identifying this client. Can be published.
+    SSO_KEY = 'random_generated_key_to_identify_the_client'
+    # A *secret* shared between client and server.
+    # Used to sign the messages exchanged between them.
+    SSO_SECRET = 'random_generated_secret_key_to_sign_exchanged_messages'
 
-  # URL used to redirect the user to the SSO server.
-  # Note: needs a trailing slash
-  SSO_SERVER_PUBLIC_URL = 'https://external-address.site.tld/'
-  # URL used for server-to-server communication
-  # Note: needs a trailing slash
-  SSO_SERVER_PRIVATE_URL = 'http://10.0.0.1:80/'
+    # URL used to redirect the user to the SSO server.
+    # Note: needs a trailing slash
+    SSO_SERVER_PUBLIC_URL = 'https://external-address.site.tld/'
+    # URL used for server-to-server communication
+    # Note: needs a trailing slash
+    SSO_SERVER_PRIVATE_URL = 'http://10.0.0.1:80/'
 
 Only for local testing of this very app do you need this additional setting::
 
-  SSO_STANDALONE = True
+    SSO_STANDALONE = True
 
 Add the proper URLS to your urls.py. Because the app needs to override the login/logout URLS,
 import them in the root of your urlpatterns::
 
-  urlpatterns = patterns(
-      '',
-      (r'^', include('lizard_auth_client.urls')),
-  )
+    urlpatterns = patterns(
+        '',
+        (r'^', include('lizard_auth_client.urls')),
+    )
 
 There is an additional setting that you can use to limit the attributes that
 are copied from the SSO server. Normally ``is_staff`` and ``is_superuser`` is
@@ -71,11 +71,11 @@ In your project's ``setup.py``, add ``lizard-auth-client[south]`` in addition
 to ``lizard-auth-client``::
 
     install_requires = [
-      ...
-      'lizard-auth-client',
-      'lizard-auth-client[south]',
-      ...
-  ],
+        ...
+        'lizard-auth-client',
+        'lizard-auth-client[south]',
+        ...
+    ],
 
 This adds the proper south (version) requirement to your project.
 
@@ -85,15 +85,15 @@ Custom authentication
 
 In a Django context, simple configure the app as above, and do::
 
-  from lizard_auth_client import client as auth_client
-  try:
-      user_data = auth_client.sso_authenticate_django('username', 'password')
-  except auth_client.AutheticationFailed as ex:
-      return some_error_handler('Auth failed')
-  except auth_client.CommunicationError as ex:
-      return some_error_handler('Temporary comm error')
-  except:
-      return some_error_handler('Other error')
+    from lizard_auth_client import client as auth_client
+    try:
+        user_data = auth_client.sso_authenticate_django('username', 'password')
+    except auth_client.AutheticationFailed as ex:
+        return some_error_handler('Auth failed')
+    except auth_client.CommunicationError as ex:
+        return some_error_handler('Temporary comm error')
+    except:
+        return some_error_handler('Other error')
 
 It should be usable without Django settings as well::
 
@@ -107,7 +107,7 @@ The middleware automaticaly logs in users when they are known at the server. And
 
 To enable you need to add to your settings file at MIDDLEWARE_CLASSES::
 
-  'lizard_auth_client.middleware.LoginRequiredMiddleware',
+    'lizard_auth_client.middleware.LoginRequiredMiddleware',
 
 
 Tests

--- a/README.rst
+++ b/README.rst
@@ -55,7 +55,6 @@ import them in the root of your urlpatterns::
     )
 
 
-
 Usage note for django < 1.7
 ---------------------------
 

--- a/README.rst
+++ b/README.rst
@@ -103,11 +103,18 @@ It should be usable without Django settings as well::
 Middleware
 ----------
 
-The middleware automaticaly logs in users when they are known at the server. And forces users to login at the server if they are not known.
+The middleware automaticaly logs in users when they are known at the
+server. And forces users to login at the server if they are not known.
 
-To enable you need to add to your settings file at MIDDLEWARE_CLASSES::
+To enable it, add this to your settings' ``MIDDLEWARE_CLASSES``::
 
+    ...
     'lizard_auth_client.middleware.LoginRequiredMiddleware',
+    ...
+
+Note: ``django.contrib.auth.middleware.AuthenticationMiddleware``, enabled by
+default, should be *above* the LoginRequiredMiddleware.
+
 
 
 Tests

--- a/lizard_auth_client/client.py
+++ b/lizard_auth_client/client.py
@@ -30,15 +30,6 @@ class CommunicationError(Exception):
 class UserNotFound(Exception):
     pass
 
-# Check some old settings we don't want to use anymore.
-if hasattr(settings, 'SSO_SYNCED_USER_KEYS'):
-    logger.warn("Deprecation warning: SSO_SYNCED_USER_KEYS isn't "
-                "used anymore, see CHANGES.rst for version 1.0.")
-
-if "p-web-ws-00-d8" in settings.SSO_SERVER_PRIVATE_URL:
-    logger.warn("Deprecation warning: outdated SSO_SERVER_PRIVATE_URL, "
-                "use 110-sso-c1 instead of p-web-ws-00-d8.")
-
 
 def _do_post(sso_server_private_url, sso_server_path, sso_key, sso_secret,
              **params):

--- a/lizard_auth_client/urls.py
+++ b/lizard_auth_client/urls.py
@@ -12,10 +12,7 @@ from django.contrib.staticfiles.urls import staticfiles_urlpatterns
 from lizard_auth_client import views
 
 
-if not hasattr(settings, 'SSO_ENABLED'):
-    sso_enabled = False
-else:
-    sso_enabled = settings.SSO_ENABLED
+sso_enabled = getattr(settings, 'SSO_ENABLED', False)
 
 
 def check_settings():

--- a/lizard_auth_client/urls.py
+++ b/lizard_auth_client/urls.py
@@ -1,13 +1,13 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
+from django.conf import settings
 from django.conf.urls import include
 from django.conf.urls import patterns
 from django.conf.urls import url
-from django.conf import settings
-from django.core.exceptions import ImproperlyConfigured
 from django.contrib import admin
 from django.contrib.staticfiles.urls import staticfiles_urlpatterns
+from django.core.exceptions import ImproperlyConfigured
 
 from lizard_auth_client import views
 
@@ -84,6 +84,7 @@ if sso_enabled:
     )
 else:
     urlpatterns = patterns('')
+
 
 if getattr(settings, 'SSO_STANDALONE', False) is True:
     # when running standalone (for testing purposes), add some extra URLS

--- a/lizard_auth_client/urls.py
+++ b/lizard_auth_client/urls.py
@@ -39,6 +39,17 @@ def check_settings():
             'SSO_SERVER_PRIVATE_URL in your settings. '
             'These URIs are used to locate the SSO server.'
         )
+    # Check some old settings we don't want to use anymore.
+    if hasattr(settings, 'SSO_SYNCED_USER_KEYS'):
+        raise ImproperlyConfigured(
+            "Deprecation warning: SSO_SYNCED_USER_KEYS isn't "
+            "used anymore, see CHANGES.rst for version 1.0.")
+
+    if "p-web-ws-00-d8" in getattr(settings, 'SSO_SERVER_PRIVATE_URL', ''):
+        raise ImproperlyConfigured(
+            "Deprecation warning: outdated SSO_SERVER_PRIVATE_URL, "
+            "use 110-sso-c1 instead of p-web-ws-00-d8.")
+
 
 if sso_enabled:
     check_settings()


### PR DESCRIPTION
Removed decprecated syned-user-keys settings doc. Added some missing documentation.

Some import ordering.

Moved checks to the "standard" location (at least in this package) inside the urls.py.