### PR TITLE
Synchronize user organisation roles when authenticating via SSOBackend.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@ Changelog of lizard-auth-client
 1.7.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Synchronize roles when authenticating via SSOBackend.
 
 
 1.7.1 (2015-10-27)

--- a/lizard_auth_client/backends.py
+++ b/lizard_auth_client/backends.py
@@ -71,10 +71,12 @@ class SSOBackend(ModelBackend):
                             (user_data, hashed_password),
                             SSO_CREDENTIAL_CACHE_TIMEOUT_SECONDS)
                 # Use either the cached user profile data, or fresh data from
-                # the SSO server to construct a Django User instance.
+                # the SSO server to construct a Django User instance. If
+                # fresh data is used, also synchronize roles.
                 if user_data:
                     user = client.construct_user(user_data)
-                    client.sso_sync_user_organisation_roles(user)
+                    if not cached_credentials:
+                        client.sso_sync_user_organisation_roles(user)
                     return user
         except:
             logger.exception('Error while authenticating user "%s".', username)

--- a/lizard_auth_client/backends.py
+++ b/lizard_auth_client/backends.py
@@ -74,6 +74,7 @@ class SSOBackend(ModelBackend):
                 # the SSO server to construct a Django User instance.
                 if user_data:
                     user = client.construct_user(user_data)
+                    client.sso_sync_user_organisation_roles(user)
                     return user
         except:
             logger.exception('Error while authenticating user "%s".', username)


### PR DESCRIPTION
This pull request solves the following issue: https://github.com/nens/lizard-nxt/issues/1178.

Somewhere in the "normal" login procedure, i.e. logging on via the web interface of one of our portals, the synchronize_roles function gets called:

https://github.com/lizardsystem/lizard-auth-client/blob/master/lizard_auth_client/client.py#L375

However, when authenticating via the SSOBackend, this is not the case:

https://github.com/lizardsystem/lizard-auth-client/blob/master/lizard_auth_client/backends.py#L27

An example of the latter is logging in via the Django REST framework login form:

https://demo.lizard.net/api-auth/login/?next=/api/v2/

The same is true for API users that send their username and password via HTTP headers. This is particularly unwieldy: many DDSC/NXT data suppliers never log on via the web interface. They only POST data to the API. Their roles are currently not synchronized, unless some management is run manually.
