### PR TITLE
String representation also works on python 3

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,10 @@ Changelog of lizard-auth-client
 1.10 (unreleased)
 -----------------
 
-- Nothing changed yet.
+- Made sure the string representation on models also works on python 3 (it
+  also keeps working on python 2, of course). See
+  https://docs.djangoproject.com/en/1.8/ref/utils/#django.utils.encoding.python_2_unicode_compatible
+  [reinout]
 
 
 1.9 (2015-11-03)

--- a/lizard_auth_client/models.py
+++ b/lizard_auth_client/models.py
@@ -1,10 +1,12 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
+from django.utils.encoding import python_2_unicode_compatible
 from django.conf import settings
 from django.db import models
 
 
+@python_2_unicode_compatible
 class Role(models.Model):
     unique_id = models.CharField(max_length=32, unique=True)
     code = models.CharField(max_length=255, null=False, blank=False)
@@ -14,7 +16,7 @@ class Role(models.Model):
 
     BILLING_ROLE_CODE = 'billing'
 
-    def __unicode__(self):
+    def __str__(self):
         return self.name
 
     @classmethod
@@ -47,6 +49,7 @@ class Role(models.Model):
         return role
 
 
+@python_2_unicode_compatible
 class Organisation(models.Model):
     # Don't make Organisation name unique because data is only
     # synchronized when someone in an organisation logs in -- we can't
@@ -54,7 +57,7 @@ class Organisation(models.Model):
     name = models.CharField(max_length=255, null=False, blank=False)
     unique_id = models.CharField(max_length=32, unique=True)
 
-    def __unicode__(self):
+    def __str__(self):
         return self.name
 
     @classmethod
@@ -75,6 +78,7 @@ class Organisation(models.Model):
         return org
 
 
+@python_2_unicode_compatible
 class UserOrganisationRole(models.Model):
     """Stores which roles in which organisations a user has."""
     user_model = getattr(settings, 'AUTH_USER_MODEL', 'auth.User')
@@ -82,7 +86,7 @@ class UserOrganisationRole(models.Model):
     organisation = models.ForeignKey(Organisation)
     role = models.ForeignKey(Role)
 
-    def __unicode__(self):
+    def __str__(self):
         return '%s %s %s' % (
             str(self.user), str(self.organisation), str(self.role))
 

--- a/lizard_auth_client/tests.py
+++ b/lizard_auth_client/tests.py
@@ -158,6 +158,10 @@ class TestOrganisation(TestCase):
         self.assertEquals(org.unique_id, "NENS")
         self.assertEquals(org.name, "Nelen & Schuurmans")
 
+    def test_prepresentation(self):
+        organisation = models.Organisation(name='Reinout')
+        self.assertTrue(repr(organisation))
+
 
 class TestRole(TestCase):
     def test_create_from_dict(self):
@@ -179,6 +183,10 @@ class TestRole(TestCase):
         self.assertEquals(role.external_description, 'Hooggeachte klant')
         self.assertEquals(role.internal_description, 'Melkkoe')
         self.assertFalse(hasattr(role, 'nog_een_veld'))
+
+    def test_prepresentation(self):
+        role = models.Role(name='Reinout')
+        self.assertTrue(repr(role))
 
 
 class TestUserOrganisationRole(TestCase):


### PR DESCRIPTION
In the ggmn staging site (python 3) I see `UserOrganisationRole object` in the admin instead of the string representation.

I've used the method described in https://docs.djangoproject.com/en/1.8/ref/utils/#django.utils.encoding.python_2_unicode_compatible to fix it.

@remcogerlich or @byrman, could one of you take a quick look? It is a very small PR.