### PR TITLE
Do not set unusable password twice.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@ Changelog of lizard-auth-client
 1.13 (unreleased)
 -----------------
 
-- Nothing changed yet.
+- Do not set unusable password twice.
 
 
 1.12 (2016-04-15)

--- a/lizard_auth_client/client.py
+++ b/lizard_auth_client/client.py
@@ -353,17 +353,16 @@ def construct_user(data):
     # create or get a User instance
     try:
         user = User.objects.get(username=local_username)
+        if user.has_usable_password():
+            user.set_unusable_password()
     except User.DoesNotExist:
         user = User()
+        user.set_unusable_password()
 
     # copy simple properies like email and first name
     for key in ['first_name', 'last_name', 'email', 'is_active']:
         setattr(user, key, data[key])
     user.username = local_username
-
-    # ensure user can't login
-    if user.has_usable_password():
-        user.set_unusable_password()
     user.save()
 
     # Note we don't set any permissions here -- not handled by SSO

--- a/lizard_auth_client/client.py
+++ b/lizard_auth_client/client.py
@@ -362,7 +362,8 @@ def construct_user(data):
     user.username = local_username
 
     # ensure user can't login
-    user.set_unusable_password()
+    if user.has_usable_password():
+        user.set_unusable_password()
     user.save()
 
     # Note we don't set any permissions here -- not handled by SSO

--- a/lizard_auth_client/tests.py
+++ b/lizard_auth_client/tests.py
@@ -97,7 +97,7 @@ class TestClient(TestCase):
                 return client.sso_populate_user_django('non_existing_username')
             self.assertRaises(client.UserNotFound, unknown_user)
 
-    def test_login_user(self):
+    def test_password_retains_when_login_twice(self):
         with mock.patch('lizard_auth_client.client._do_post', return_value={
                 'success': True,
                 'user': {'username': 'root',

--- a/lizard_auth_client/tests.py
+++ b/lizard_auth_client/tests.py
@@ -2,12 +2,12 @@
 from __future__ import unicode_literals
 
 import logging
+import mock
 import pprint
 
 from django.contrib.auth.models import User
 from django.test import TestCase
 from faker import Faker
-import mock
 
 from lizard_auth_client import backends
 from lizard_auth_client import client
@@ -96,6 +96,21 @@ class TestClient(TestCase):
             def unknown_user():
                 return client.sso_populate_user_django('non_existing_username')
             self.assertRaises(client.UserNotFound, unknown_user)
+
+    def test_login_user(self):
+        with mock.patch('lizard_auth_client.client._do_post', return_value={
+                'success': True,
+                'user': {'username': 'root',
+                         'first_name': 'Willie',
+                         'last_name': 'Wortel',
+                         'email': 'noreply@example.com',
+                         'is_active': True,
+                         'is_staff': False,
+                         'is_superuser': False}}):
+            user = client.sso_populate_user_django('root')
+            password = user.password
+            user = client.sso_populate_user_django('root')
+            self.assertEqual(user.password, password)
 
 
 class TestSuperuserStaffCallback(TestCase):


### PR DESCRIPTION
Before, when a user logged in, his password was set to an unusable one, even when this password was already unusable. This caused issues with SessionAuthenticationMiddleware. When the user logged on to another portal (or in another browser) his password was changed to a different unusable one, rendering his old session invalid.

Now, unusable passwords will be left at peace.