### PR TITLE
Make UserFactory create a syntactically valid email address.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@ Changelog of lizard-auth-client
 2.4 (unreleased)
 ----------------
 
-- Nothing changed yet.
+- Fixed UserFactory: it now creates a syntactically valid email address.
 
 
 2.3 (2016-09-26)

--- a/lizard_auth_client/factories.py
+++ b/lizard_auth_client/factories.py
@@ -25,7 +25,7 @@ class UserFactory(factory.DjangoModelFactory):
         lambda x: '{}.{}'.format(slugify(x.first_name), slugify(x.last_name)))
     password = factory.Faker('password')
     email = factory.LazyAttribute(
-        lambda x: '{}@gmail'.format(x.username))
+        lambda x: '{}@gmail.com'.format(x.username))
     is_superuser = False
     is_staff = False
     is_active = True


### PR DESCRIPTION
Solves https://github.com/lizardsystem/lizard-auth-client/issues/54