### PR TITLE
Cleanup docker network

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,6 +9,7 @@ node {
 
    stage "Test"
    sh "docker-compose run web bin/test"
+   sh "docker-compose down"
    step $class: 'JUnitResultArchiver', testResults: 'nosetests.xml'
    publishHTML target: [reportDir: 'htmlcov', reportFiles: 'index.html', reportName: 'Coverage report']
 }


### PR DESCRIPTION
@jsmits: hiermee wordt volgens mij netjes het aangemaakte docker netwerk weggehaald en ook de tussentijdse images.

Zie https://docs.docker.com/compose/reference/down/

Dit is de output van jenkins:

    Removing clientreinoutnicedockerm4l2srhoyzxt2gc6b7ldnp7y3qmqzbgkpimvkvzvupee776j7mia_web_run_3 ...
    Removing clientreinoutnicedockerm4l2srhoyzxt2gc6b7ldnp7y3qmqzbgkpimvkvzvupee776j7mia_web_run_2 ...
    Removing clientreinoutnicedockerm4l2srhoyzxt2gc6b7ldnp7y3qmqzbgkpimvkvzvupee776j7mia_web_run_1 ...
    Removing clientreinoutnicedockerm4l2srhoyzxt2gc6b7ldnp7y3qmqzbgkpimvkvzvupee776j7mia_web_run_3 ... done
    Removing network clientreinoutnicedockerm4l2srhoyzxt2gc6b7ldnp7y3qmqzbgkpimvkvzvupee776j7mia_default


Dit lijkt me een mooie om overal in onze Jenkinsfiles te zetten, toch?