### PR TITLE
[DONE] Fix authentication in Django 2.1

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,8 @@ Changelog of lizard-auth-client
 2.16 (unreleased)
 -----------------
 
-- Nothing changed yet.
+- Make the signature of the authenticate method of SSOBackend compatible with
+  Django 2.1 without breaking older versions.
 
 
 2.15 (2018-09-03)

--- a/lizard_auth_client/backends.py
+++ b/lizard_auth_client/backends.py
@@ -25,7 +25,8 @@ class SSOBackend(ModelBackend):
     Set SSO_CREDENTIAL_CACHE_TIMEOUT_SECONDS for this.
     """
 
-    def authenticate(self, username=None, password=None):
+    def authenticate(self, request=None, username=None, password=None,
+                     **kwargs):
         try:
             if username and password:
                 user_data = None


### PR DESCRIPTION
In function `django.contrib.auth.__init__.authenticate` the signature of the `authenticate` method of the various authentication backends is inspected. Django 2.1 silently skips backends that do not comply! Our custom SSOBackend is used across different versions of Django, so it is very important to have the signature right.