### PR TITLE
Add support to dump and restore UserOrganisationRoles by natural key.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@ Changelog of lizard-auth-client
 2.17 (unreleased)
 -----------------
 
-- Added a migration to delete dupicate UserOrganisationRoles (keeping 1).
+- Added a migration to delete duplicate UserOrganisationRoles (keeping 1).
 
 - Added a unique_together constraint to UserOrganisationRole (user,
   organisation, role).

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,12 @@ Changelog of lizard-auth-client
 2.17 (unreleased)
 -----------------
 
-- Nothing changed yet.
+- Added a migration to delete dupicate UserOrganisationRoles (keeping 1).
+
+- Added a unique_together constraint to UserOrganisationRole (user,
+  organisation, role).
+
+- Added support for dumping and restoring UserOrganisationRoles by natural key.
 
 
 2.16 (2018-11-01)

--- a/lizard_auth_client/migrations/0005_auto_20181115_1249.py
+++ b/lizard_auth_client/migrations/0005_auto_20181115_1249.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations
+
+
+def delete_duplicate_uors(apps, schema_editor):
+    """Delete duplicate UserOrganisationRoles."""
+    UOR = apps.get_model('lizard_auth_client', 'UserOrganisationRole')
+    for row in UOR.objects.all():
+        if UOR.objects.filter(
+            user=row.user,
+            organisation=row.organisation,
+            role=row.role
+        ).count() > 1:
+            row.delete()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('lizard_auth_client', '0004_auto_20170104_1432'),
+    ]
+
+    operations = [
+        migrations.RunPython(delete_duplicate_uors),
+    ]

--- a/lizard_auth_client/migrations/0006_auto_20181115_1313.py
+++ b/lizard_auth_client/migrations/0006_auto_20181115_1313.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('lizard_auth_client', '0005_auto_20181115_1249'),
+    ]
+
+    operations = [
+        migrations.AlterUniqueTogether(
+            name='userorganisationrole',
+            unique_together=set([('user', 'organisation', 'role')]),
+        ),
+    ]


### PR DESCRIPTION
I have to transfer permissions (i.e. UserOrganisationRoles) to another database. This would be a lot easier if dumping and restoring objects by natural key is supported.