### PR TITLE
Fix missing iss claim

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: python
 python:
   - 2.7
+  - 3.6
 cache:
   directories:
     - eggs

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,8 @@ Changelog of lizard-auth-client
 2.18 (unreleased)
 -----------------
 
-- Nothing changed yet.
+- Fixed user management form (could not create a new user on the SSO server
+  due to a missing iss JWT claim).
 
 
 2.17 (2018-11-16)

--- a/lizard_auth_client/client.py
+++ b/lizard_auth_client/client.py
@@ -788,6 +788,7 @@ def _sso_create_user_request_by_payload(payload):
     """
     from lizard_auth_client.conf import settings
 
+    payload['iss'] = settings.SSO_KEY
     signed_message = jwt.encode(payload, settings.SSO_SECRET,
                                 algorithm=settings.SSO_JWT_ALGORITHM)
     url = sso_server_url('new-user')


### PR DESCRIPTION
Adding a _totally_ new user (i.e. a user that doesn't exist on the SSO server yet) currently fails dues to a missing iss claim. This ValidationError at the SSO is hit:

https://github.com/lizardsystem/lizard-auth-server/blob/master/lizard_auth_server/forms.py#L125