### PR TITLE
User management case sensitive email field THREEDI-689

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@ Changelog of lizard-auth-client
 3.1 (unreleased)
 ----------------
 
-- Nothing changed yet.
+- User management case sensitive email field.
 
 
 3.0 (2019-01-15)

--- a/lizard_auth_client/forms.py
+++ b/lizard_auth_client/forms.py
@@ -135,7 +135,7 @@ class ManageUserAddForm(ManageUserBaseForm):
         if 'email' in self.cleaned_data:
             model = get_user_model()
             email = self.cleaned_data['email']
-            if model.objects.filter(email=email).exists():
+            if model.objects.filter(email__iexact=email).exists():
                 exclude.append('username')
         return exclude
 

--- a/lizard_auth_client/tests.py
+++ b/lizard_auth_client/tests.py
@@ -932,7 +932,13 @@ class TestRoleManagement(TestCase):
         """
         self.user_1 = factories.UserFactory.create(username='user_1')
         self.user_2 = factories.UserFactory.create(username='user_2')
-
+        self.user_3 = factories.UserFactory.create(username='user_3')
+        self.data_user_4 = {
+            'email': str(self.user_3.email).swapcase(),
+            'username': self.user_3.username,
+            'first_name': self.user_3.first_name,
+            'last_name': self.user_3.last_name,
+        }
         self.organisation_1 = factories.OrganisationFactory.create(
             name='organisation_1')
         self.organisation_2 = factories.OrganisationFactory.create(
@@ -1037,6 +1043,18 @@ class TestRoleManagement(TestCase):
         self.assertTrue('role_run_simulation' in form.fields.keys())
         self.assertTrue('role_change_model' in form.fields.keys())
         self.assertTrue('role_manage' in form.fields.keys())
+
+    def test_email_case_insensitive(self):
+        """test for an existing user, we try to add to a different
+        organization with an email containing capital letters"""
+        form = forms.ManageUserAddForm(
+            data=self.data_user_4,
+        )
+        self.assertTrue(form.is_valid())
+        form.save()
+        self.assertEqual(form.validate_unique(), None)
+        exclude = form._get_validation_unique_exclusions()
+        self.assertTrue('username' in exclude)
 
     def test_change_user_form(self):
         user_roles = self.available_roles

--- a/lizard_auth_client/tests.py
+++ b/lizard_auth_client/tests.py
@@ -1051,7 +1051,6 @@ class TestRoleManagement(TestCase):
             data=self.data_user_4,
         )
         self.assertTrue(form.is_valid())
-        form.save()
         self.assertEqual(form.validate_unique(), None)
         exclude = form._get_validation_unique_exclusions()
         self.assertTrue('username' in exclude)

--- a/lizard_auth_client/tests.py
+++ b/lizard_auth_client/tests.py
@@ -932,13 +932,6 @@ class TestRoleManagement(TestCase):
         """
         self.user_1 = factories.UserFactory.create(username='user_1')
         self.user_2 = factories.UserFactory.create(username='user_2')
-        self.user_3 = factories.UserFactory.create(username='user_3')
-        self.data_user_4 = {
-            'email': str(self.user_3.email).swapcase(),
-            'username': self.user_3.username,
-            'first_name': self.user_3.first_name,
-            'last_name': self.user_3.last_name,
-        }
         self.organisation_1 = factories.OrganisationFactory.create(
             name='organisation_1')
         self.organisation_2 = factories.OrganisationFactory.create(
@@ -1047,8 +1040,15 @@ class TestRoleManagement(TestCase):
     def test_email_case_insensitive(self):
         """test for an existing user, we try to add to a different
         organization with an email containing capital letters"""
+        user_3 = factories.UserFactory.create(username='user_3')
+        data_user_4 = {
+            'email': str(user_3.email).swapcase(),
+            'username': user_3.username,
+            'first_name': user_3.first_name,
+            'last_name': user_3.last_name,
+        }
         form = forms.ManageUserAddForm(
-            data=self.data_user_4,
+            data=data_user_4,
         )
         self.assertTrue(form.is_valid())
         self.assertEqual(form.validate_unique(), None)


### PR DESCRIPTION
**Description:**
In https://3di.lizard.net/management/organisations/ :

Inserting a user that already exists in SSO requires entry of email and username. The email check with SSO is case sensitive, which leads to problems (e.g. with Rebecca not knowing that she is registered under R‌ebecca.van‌W‌eesep@nelen-schuurmans.nl). In Lizard this has already been fixed, so there should not be any restrictions from lizard_auth_client in resolving this.

Jira link: https://nelen-schuurmans.atlassian.net/browse/THREEDI-689