### PR TITLE
Extend Organisation with a  uuid property and setter.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@ Changelog of lizard-auth-client
 3.0.4 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Extended the Organisation model with a `uuid` property and setter.
 
 
 3.0.3 (2020-06-25)

--- a/lizard_auth_client/models.py
+++ b/lizard_auth_client/models.py
@@ -3,6 +3,7 @@ from __future__ import unicode_literals
 from django.db import models
 from django.utils.encoding import python_2_unicode_compatible
 from lizard_auth_client.conf import settings
+from uuid import UUID
 
 
 class RoleManager(models.Manager):
@@ -81,6 +82,14 @@ class Organisation(models.Model):
 
     def __str__(self):
         return self.name
+
+    @property
+    def uuid(self):
+        return UUID(self.unique_id)
+
+    @uuid.setter
+    def uuid(self, value):
+        self.unique_id = UUID(str(value)).hex
 
     def natural_key(self):
         return (self.unique_id, )

--- a/lizard_auth_client/models.py
+++ b/lizard_auth_client/models.py
@@ -75,6 +75,8 @@ class Organisation(models.Model):
     # synchronized when someone in an organisation logs in -- we can't
     # guarantee that names will stay unique that way.
     name = models.CharField(max_length=255, null=False, blank=False)
+    # In hindsight, UUIDField might have been a better choice for unique_id.
+    # The uuid property and setter may be used as an alternative.
     unique_id = models.CharField(max_length=32, unique=True)
 
     class Meta:
@@ -85,10 +87,12 @@ class Organisation(models.Model):
 
     @property
     def uuid(self):
+        """An alternative getter for unique_id."""
         return UUID(self.unique_id)
 
     @uuid.setter
     def uuid(self, value):
+        """An alternative setter for unique_id."""
         self.unique_id = UUID(str(value)).hex
 
     def natural_key(self):

--- a/lizard_auth_client/tests.py
+++ b/lizard_auth_client/tests.py
@@ -25,11 +25,12 @@ from lizard_auth_client.models import get_user_org_role_dict
 from requests.exceptions import HTTPError
 
 import inspect
+import json
 import jwt
 import logging
 import mock
 import pprint
-import json
+import uuid
 
 logger = logging.getLogger(__name__)
 fake = Faker()
@@ -226,6 +227,19 @@ class TestOrganisation(TestCase):
         # Check that is has been saved and the fields are correct
         self.assertTrue(org.pk)
         self.assertEquals(org.unique_id, "NENS")
+        self.assertEquals(org.name, "Nelen & Schuurmans")
+
+    def test_create_from_uuid(self):
+        uuid = uuid.uuid4()
+        org = models.Organisation.create_from_uuid({
+            'uuid': uuid,
+            'name': "Nelen & Schuurmans"
+        })
+
+        # Check that is has been saved and the fields are correct
+        self.assertTrue(org.pk)
+        self.assertEquals(org.uuid, uuid)
+        self.assertEquals(org.unique_id, uuid.hex)
         self.assertEquals(org.name, "Nelen & Schuurmans")
 
     def test_prepresentation(self):


### PR DESCRIPTION
Changing `unique_id` into a UUIDField might break things (?), but a separate property seems both harmless and useful (e.g. for serializing `unique_id` as a proper UUID).